### PR TITLE
Fix modulo calculation

### DIFF
--- a/src/PartSegCore_compiled_backend/_napari_mapping.pyx
+++ b/src/PartSegCore_compiled_backend/_napari_mapping.pyx
@@ -28,23 +28,23 @@ ctypedef fused out_types:
     out_types_mod
     cnp.float32_t
 
-def _zero_preserving_modulo_seq(label_types[:] labels,  label_types modulo, label_types to_zero, out_types_mod[:] out):
+def _zero_preserving_modulo_seq(label_types[:] labels,  out_types_mod modulo, label_types to_zero, out_types_mod[:] out):
     cdef Py_ssize_t i
     cdef Py_ssize_t n = labels.shape[0]
     for i in range(n):
         if labels[i] == to_zero:
             out[i] = 0
         else:
-            out[i] = ((labels[i] - 1)  % modulo) + 1
+            out[i] = (modulo + ((labels[i] - 1) % modulo) % modulo) + 1
 
-def _zero_preserving_modulo_par(label_types[:] labels, label_types modulo, label_types to_zero, out_types_mod[:] out):
+def _zero_preserving_modulo_par(label_types[:] labels, out_types_mod modulo, label_types to_zero, out_types_mod[:] out):
     cdef Py_ssize_t i
     cdef Py_ssize_t n = labels.shape[0]
     for i in prange(n, nogil=True):
         if labels[i] == to_zero:
             out[i] = 0
         else:
-            out[i] = ((labels[i] - 1) % modulo) + 1
+            out[i] = (modulo + ((labels[i] - 1) % modulo) % modulo) + 1
 
 
 def _map_array_par(label_types[:] labels, dict dkt, out_types[:] out, out_types def_val=0):

--- a/src/PartSegCore_compiled_backend/_napari_mapping.pyx
+++ b/src/PartSegCore_compiled_backend/_napari_mapping.pyx
@@ -35,7 +35,7 @@ def _zero_preserving_modulo_seq(label_types[:] labels,  out_types_mod modulo, la
         if labels[i] == to_zero:
             out[i] = 0
         else:
-            out[i] = (modulo + ((labels[i] - 1) % modulo) % modulo) + 1
+            out[i] = ((modulo + ((labels[i] - 1) % modulo)) % modulo) + 1
 
 def _zero_preserving_modulo_par(label_types[:] labels, out_types_mod modulo, label_types to_zero, out_types_mod[:] out):
     cdef Py_ssize_t i
@@ -44,7 +44,7 @@ def _zero_preserving_modulo_par(label_types[:] labels, out_types_mod modulo, lab
         if labels[i] == to_zero:
             out[i] = 0
         else:
-            out[i] = (modulo + ((labels[i] - 1) % modulo) % modulo) + 1
+            out[i] = ((modulo + ((labels[i] - 1) % modulo)) % modulo) + 1
 
 
 def _map_array_par(label_types[:] labels, dict dkt, out_types[:] out, out_types def_val=0):

--- a/src/tests/test_napari_mapping.py
+++ b/src/tests/test_napari_mapping.py
@@ -37,6 +37,19 @@ def test_zero_preserving_modulo(func, data):
     npt.assert_array_equal(out, _zero_preserving_modulo_numpy(data, 10, np.uint8, 0))
 
 
+@pytest.mark.parametrize('func', [zero_preserving_modulo_parallel, zero_preserving_modulo_sequential])
+@pytest.mark.parametrize('background_num', [0, 1, 2, -1])
+def test_background_label(func, background_num):
+    data = np.zeros((10, 10), dtype=np.int32)
+    data[1:-1, 1:-1] = 1
+    data[2:-2, 2:-2] = 2
+    data[4:-4, 4:-4] = -1
+
+    res = func(data, 49, background_num)
+    np.testing.assert_array_equal(res == 0, data == background_num)
+    np.testing.assert_array_equal(res != 0, data != background_num)
+
+
 @pytest.mark.parametrize('func', [map_array_parallel, map_array_sequential])
 @pytest.mark.parametrize('data', DATA_LI, ids=DATA_IDS)
 def test_map_array(func, data):


### PR DESCRIPTION
When c/c++ modulo operation for negative numbers returns negative value, when python one returns positive values:

```c++
#include<iostream>

int main() {
    int result = -1 % 45;
    std::cout << result;
    return 0;
}
```
will print -1

```python
print(-1 % 45)
```
Will print 44. 

This PR fixes this. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved internal logic for certain processing functions to enhance performance and accuracy.

- **Tests**
  - Implemented new tests to ensure correct handling of background labels in data processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->