### PR TITLE
Add codespell to pre-commit hooks 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,3 +29,9 @@ repos:
     rev: v0.12.0  # Use the ref you want to point at
     hooks:
     - id: markdownlint
+-   repo: https://github.com/codespell-project/codespell
+    rev: v2.3.0
+    hooks:
+    - id: codespell
+      additional_dependencies:
+      - tomli

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,3 +131,6 @@ indent-style = "space"
 docstring-code-format = true
 line-ending = "lf"
 skip-magic-trailing-comma = true
+
+[tool.codespell]
+skip = "notebooks/*"

--- a/src/PartSegCore_compiled_backend/multiscale_opening/mso.h
+++ b/src/PartSegCore_compiled_backend/multiscale_opening/mso.h
@@ -322,7 +322,7 @@ class MSO {
                          std::vector<mu_type> distances) {
     if (neighbourhood.size() != ndim * distances.size()) {
       throw std::length_error(
-          "Size of neighbouthood need to be 3* Size of distances");
+          "Size of neighbourhood need to be 3* Size of distances");
     }
     this->neighbourhood = neighbourhood;
     this->distances = distances;

--- a/src/PartSegCore_compiled_backend/sprawl_utils/euclidean_cython.pyx
+++ b/src/PartSegCore_compiled_backend/sprawl_utils/euclidean_cython.pyx
@@ -21,7 +21,7 @@ def calculate_euclidean(np.ndarray[uint8_t, ndim=3] object_area, np.ndarray[uint
     :param base_object: Core object from which watersheed start
     :param neighbourhood: negihbourhood defined as array of size (neigbourhood_size, 3)
     :param distance: array for distances of negibours. Need have size (neighbourhood_szie).
-        Used for handling spacin in image.
+        Used for handling spacinh in image.
     :return: distance from core object
     """
     cdef np.ndarray[uint8_t, ndim=3] consumed_area = np.copy(base_object)


### PR DESCRIPTION
Fix spelling mistakes pointed by codespell.

Exclude notebooks because codespell finds mistakes in binary data blobs.
https://github.com/codespell-project/codespell/issues/2138


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Integrated the `codespell` tool to identify and correct common spelling errors in code.
	- Added configuration to exclude the `notebooks` directory from spell-checking.
  
- **Bug Fixes**
	- Corrected the spelling in error messages related to the `neighbourhood` vector.

- **Documentation**
	- Updated the docstring for the `calculate_euclidean` function to correct typographical errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->