### PR TITLE
Add option to deduplicate edges in edge triangulation 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ sdist.include = ["src/PartSegCore_compiled_backend/version.py"]
 cmake.version = ">=3.21"
 sdist.exclude = [".github", "tox.ini", "build_utils", "notebooks", ".readthedocs.yaml"]
 wheel.exclude = ["**.pyx"]
-cmake.build-type = "Debug"
+#cmake.build-type = "Debug"
 
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ sdist.include = ["src/PartSegCore_compiled_backend/version.py"]
 cmake.version = ">=3.21"
 sdist.exclude = [".github", "tox.ini", "build_utils", "notebooks", ".readthedocs.yaml"]
 wheel.exclude = ["**.pyx"]
-#cmake.build-type = "Debug"
+cmake.build-type = "Debug"
 
 
 [project]

--- a/src/PartSegCore_compiled_backend/triangulate.pyx
+++ b/src/PartSegCore_compiled_backend/triangulate.pyx
@@ -436,6 +436,7 @@ def triangulate_polygon_with_edge_numpy_li(polygon_li: list[np.ndarray], split_e
     cdef pair[vector[Triangle], vector[Point]] triangulation_result
     cdef vector[PathTriangulation] edge_result
     cdef cnp.ndarray[cnp.uint32_t, ndim=2] triangles, edge_triangles
+    cdef size_t triangle_count = 0
 
     cdef cnp.ndarray[cnp.float32_t, ndim=2] points, edge_offsets, edges_centers, polygon
     cdef size_t i, j, len_path, edge_triangle_count, edge_center_count, edge_triangle_index, edge_center_index
@@ -475,7 +476,7 @@ def triangulate_polygon_with_edge_numpy_li(polygon_li: list[np.ndarray], split_e
         triangles[i, 1] = triangulation_result.first[i].y
         triangles[i, 2] = triangulation_result.first[i].z
 
-    points =np.empty((triangulation_result.second.size(), 2), dtype=np.float32)
+    points = np.empty((triangulation_result.second.size(), 2), dtype=np.float32)
     for i in range(triangulation_result.second.size()):
         points[i, 0] = triangulation_result.second[i].x
         points[i, 1] = triangulation_result.second[i].y
@@ -494,10 +495,11 @@ def triangulate_polygon_with_edge_numpy_li(polygon_li: list[np.ndarray], split_e
     edge_center_index = 0
     for i in range(edge_result.size()):
         for j in range(edge_result[i].triangles.size()):
-            edge_triangles[edge_triangle_index, 0] = edge_result[i].triangles[j].x
-            edge_triangles[edge_triangle_index, 1] = edge_result[i].triangles[j].y
-            edge_triangles[edge_triangle_index, 2] = edge_result[i].triangles[j].z
+            edge_triangles[edge_triangle_index, 0] = edge_result[i].triangles[j].x + triangle_count
+            edge_triangles[edge_triangle_index, 1] = edge_result[i].triangles[j].y + triangle_count
+            edge_triangles[edge_triangle_index, 2] = edge_result[i].triangles[j].z + triangle_count
             edge_triangle_index += 1
+        triangle_count += edge_result[i].centers.size()
 
         for j in range(edge_result[i].centers.size()):
             edges_centers[edge_center_index, 0] = edge_result[i].centers[j].x

--- a/src/PartSegCore_compiled_backend/triangulate.pyx
+++ b/src/PartSegCore_compiled_backend/triangulate.pyx
@@ -13,8 +13,6 @@ from libcpp cimport bool
 from libcpp.unordered_set cimport unordered_set
 from libcpp.utility cimport pair
 from libcpp.vector cimport vector
-from libcpp.unordered_map cimport unordered_map
-from libcpp.algorithm cimport sort
 
 
 cdef extern from "triangulation/point.hpp" namespace "partsegcore::point":

--- a/src/PartSegCore_compiled_backend/triangulation/triangulate.hpp
+++ b/src/PartSegCore_compiled_backend/triangulation/triangulate.hpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <set>
 #include <sstream>
+#include <stack>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -1286,6 +1287,32 @@ inline PathTriangulation triangulate_path_edge(
   }
   result.fix_triangle_orientation();
   return result;
+}
+
+std::vector<std::vector<point::Point>> split_polygon_on_repeated_edges(
+    std::vector<point::Point> polygon) {
+  std::unordered_map<point::Point, std::vector<size_t>> point_to_index;
+  std::stack<std::size_t> stack = {0};
+  for (std::size_t i = 0; i < polygon.size(); i++) {
+    point_to_index[polygon[i]].emplace_back(i);
+  }
+  if (point_to_index.size() == polygon.size()) {
+    // no repeated points
+    return {polygon};
+  }
+  std::vector<std::vector<point::Point>> new_polygons_list;
+  new_polygons_list.push_back({});
+  for (std::size_t i = 0; i < polygon.size(); i++) {
+    auto &point = polygon[i];
+    if (point_to_index[point].size() == 1) {
+      new_polygons_list[stack.top()].push_back(point);
+    } else {
+      new_polygons_list[stack.top()].push_back(point);
+      if stack
+        .push(new_polygons_list.size());
+      new_polygons_list.push_back({});
+    }
+  }
 }
 
 }  // namespace partsegcore::triangulation

--- a/src/PartSegCore_compiled_backend/triangulation/triangulate.hpp
+++ b/src/PartSegCore_compiled_backend/triangulation/triangulate.hpp
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <map>
+#include <memory>  // memory header is required on linux, and not on macos
 #include <queue>
 #include <set>
 #include <sstream>

--- a/src/PartSegCore_compiled_backend/triangulation/triangulate.hpp
+++ b/src/PartSegCore_compiled_backend/triangulation/triangulate.hpp
@@ -4,7 +4,6 @@
 #include <algorithm>
 #include <map>
 #include <memory>  // memory header is required on linux, and not on macos
-#include <queue>
 #include <set>
 #include <sstream>
 #include <unordered_map>
@@ -1288,12 +1287,22 @@ inline PathTriangulation triangulate_path_edge(
   return result;
 }
 
+/**
+ * Represents an edge in a graph structure used for polygon processing.
+ * Each edge contains a reference to its opposite point and a flag to track
+ * if it has been visited during graph traversal.
+ */
 struct GraphEdge {
   point::Point opposite_point;
   bool visited;
   explicit GraphEdge(point::Point p) : opposite_point(p), visited(false) {}
 };
 
+/**
+ * Represents a node in a graph structure used for polygon processing.
+ * Each node contains its edges, a sub-index for traversal tracking,
+ * and a visited flag for graph traversal.
+ */
 struct GraphNode {
   std::vector<GraphEdge> edges;
   std::size_t sub_index;
@@ -1302,10 +1311,23 @@ struct GraphNode {
   GraphNode() : sub_index(0), visited(false) {}
 };
 
+/**
+ * Splits a polygon into sub-polygons by identifying and removing edges that
+ * appear more than once in the polygon's edge list.
+ *
+ * This function processes the given polygon and separates it wherever an
+ * edge is repeated. It generates a collection of sub-polygons such that each
+ * resulting sub-polygon contains unique edges. This operation can help to
+ * resolve ambiguities in complex or self-intersecting polygons.
+ *
+ * @param polygon The input polygon represented as a list of edges.
+ *
+ * @return A vector of sub-polygons, where each sub-polygon is free of repeated
+ * edges.
+ */
 inline std::vector<std::vector<point::Point>> split_polygon_on_repeated_edges(
     const std::vector<point::Point> &polygon) {
   auto edges_dedup = calc_dedup_edges({polygon});
-  std::vector<bool> visited(polygon.size(), false);
   std::vector<std::vector<point::Point>> result;
   point::Segment segment;
 

--- a/src/tests/test_triangulate.py
+++ b/src/tests/test_triangulate.py
@@ -10,6 +10,7 @@ from PartSegCore_compiled_backend.triangulate import (
     on_segment,
     orientation,
     segment_left_to_right_comparator,
+    split_polygon_on_repeated_edges_py,
     triangle_convex_polygon,
     triangulate_monotone_polygon_py,
     triangulate_path_edge_numpy,
@@ -661,3 +662,30 @@ def test_triangulate_polygon_with_edge_numpy_li(polygon, expected):
     triangles_ = _renumerate_triangles(polygon, points, triangles)
     assert triangles_ == expected
     assert centers.shape == offsets.shape
+
+
+def test_split_polygon_on_repeated_edges_py_no_split():
+    res = split_polygon_on_repeated_edges_py([[0, 0], [0, 1], [1, 1], [1, 0]])
+    assert len(res) == 1
+    assert len(res[0]) == 4
+    idx = res[0].index((0, 0))
+    assert res[0][idx:] + res[0][:idx] == [(0, 0), (0, 1), (1, 1), (1, 0)]
+
+
+def test_split_polygon_on_repeated_edges_py_square_in_square():
+    res = split_polygon_on_repeated_edges_py()
+    assert len(res) == 2
+    assert len(res[0]) == 5
+    assert len(res[1]) == 5
+    # idx = res[0].index((0, 0))
+    # assert res[0][idx:] + res[0][:idx] == [(0, 0), (0, 1), (1, 1), (1, 0)]
+
+
+@pytest.mark.parametrize(('split_edges', 'triangles'), [(True, 20), (False, 24)])
+def test_splitting_edges(split_edges, triangles):
+    polygon = np.array(
+        [[0, 0], [0, 5], [1, 5], [1, 1], [9, 1], [9, 9], [1, 9], [1, 5], [0, 5], [0, 10], [10, 10], [10, 0]],
+        dtype=np.float32,
+    )
+    triangles_ = triangulate_polygon_with_edge_numpy_li([polygon], split_edges=split_edges)[1][2]
+    assert len(triangles_) == triangles

--- a/src/tests/test_triangulate.py
+++ b/src/tests/test_triangulate.py
@@ -673,7 +673,9 @@ def test_split_polygon_on_repeated_edges_py_no_split():
 
 
 def test_split_polygon_on_repeated_edges_py_square_in_square():
-    res = split_polygon_on_repeated_edges_py()
+    res = split_polygon_on_repeated_edges_py(
+        [[0, 0], [0, 5], [1, 5], [1, 1], [9, 1], [9, 9], [1, 9], [1, 5], [0, 5], [0, 10], [10, 10], [10, 0]]
+    )
     assert len(res) == 2
     assert len(res[0]) == 5
     assert len(res[1]) == 5


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced polygon triangulation with support for handling repeated edges.
	- Added ability to split polygons with overlapping edges before triangulation.
	- Introduced new structures to facilitate edge and node representation in polygon processing.

- **Tests**
	- Added comprehensive test cases for polygon splitting and triangulation scenarios, focusing on handling repeated edges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->