### PR TITLE
chore: Add missed type annotation to fix cython compilation bug

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,3 @@
-default_language_version:
-    python: python3.9
-
 repos:
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Minimum requirements for the build system to execute.
 requires = [
     "scikit-build-core",
-    "Cython<3.1", # see https://github.com/cython/cython/issues/6974
+    "Cython",
     "cython-cmake",
     "numpy>=2",
     "setuptools_scm[toml]>=8.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,12 @@
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ["scikit-build-core", "Cython<3.1", "cython-cmake", "numpy>=2", "setuptools_scm[toml]>=8.1"]  # PEP 508 specifications.
+requires = [
+    "scikit-build-core",
+    "Cython<3.1", # see https://github.com/cython/cython/issues/6974
+    "cython-cmake",
+    "numpy>=2",
+    "setuptools_scm[toml]>=8.1"
+]  # PEP 508 specifications.
 build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ["scikit-build-core", "Cython", "cython-cmake", "numpy>=2", "setuptools_scm[toml]>=8.1"]  # PEP 508 specifications.
+requires = ["scikit-build-core", "Cython<3.1", "cython-cmake", "numpy>=2", "setuptools_scm[toml]>=8.1"]  # PEP 508 specifications.
 build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]

--- a/src/PartSegCore_compiled_backend/_fast_unique.pyx
+++ b/src/PartSegCore_compiled_backend/_fast_unique.pyx
@@ -27,7 +27,7 @@ ctypedef fused numpy_int_types:
 def unique1d(np.ndarray[numpy_int_types, ndim=1] array):
     cdef unordered_set[numpy_int_types] unique_values
     cdef vector[unordered_set[numpy_int_types]] unique_values_vector
-    cdef Py_ssize_t i, j, n_rows, n_cols, id_num
+    cdef Py_ssize_t i, j, n_rows, n_cols, id_num, n_items
     cdef numpy_int_types prev_val, v
     n_items = array.shape[0]
     unique_values_vector.resize(50) # openmp.omp_get_num_threads())


### PR DESCRIPTION
Add type annotation to variable to fix cython compilation. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
	- Updated tool configuration to remove a specific Python version setting.
	- Reformatted build system dependencies list for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->