### PR TITLE
Add python 3.14 and more platforms for wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ windows-latest, macos-latest, ubuntu-latest ]
-        python_version: [ '3.9' , '3.10', '3.11', '3.12' ]
+        python_version: [ '3.9', '3.13', '3.14' ]
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
@@ -63,7 +63,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest, macos-13 ]
+        os: [ ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-latest, macos-13 ]
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -29,6 +29,7 @@ jobs:
         name: Install Python ${{ matrix.python_version }}
         with:
           python-version: ${{ matrix.python_version }}
+          allow-prereleases: true
       - name: install openblas
         if: runner.os == 'macOS'
         run: brew install libomp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,7 @@ test-command = "pytest {project}/src/tests"
 test-extras = ["test"]
 skip = "pp*macos* pp31* pp39-manylinux*"
 build = "*64"
+enable = ["pypy", "cpython-freethreading"]
 
 [tool.cibuildwheel.macos]
 before-all = [

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py39, py310, py311, py312
+envlist = py39, py310, py311, py312, py313, py314
 
 [gh-actions]
 python =
@@ -12,6 +12,8 @@ python =
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
+    3.14: py314
 
 [testenv]
 # passenv = DISPLAY XAUTHORITY


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * CI test matrix updated to run on Python 3.9, 3.13, and 3.14 (dropped 3.10–3.12); tox and GitHub Actions now include py313 and py314.  
  * CI setup now allows prerelease Python versions.

* **Chores**
  * Build targets expanded to include Ubuntu 24.04 ARM in addition to existing Ubuntu, Windows, and macOS platforms.  
  * Release builds now request PyPy and a freethreading CPython variant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->