### PR TITLE
chore: upgrade runner for intel macos wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-latest, macos-13 ]
+        os: [ ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-latest, macos-15-intel ]
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Replace GHA runner `macos-13` with `macos-15-intel`, as `macos-13` is no longer available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure configuration.

---

**Note:** This release contains no user-facing changes. The update is purely internal to the build system and does not affect application functionality or features.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->